### PR TITLE
Use Protoc Server Stubs Directly

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,9 +29,9 @@
   (grpc-protoc
    (>= 0.2.0-preview.2))
   (ocaml-protoc
-   (>= 3.0))
+   (>= 3.0.2-preview.1))
   (pbrt_services
-   (>= 3.0))
+   (>= 3.0.2-preview.1))
   (ppx_js_style
    (and
     (>= v0.16)
@@ -177,9 +177,9 @@
   (grpc-stream
    (= :version))
   (pbrt
-   (>= 3.0))
+   (>= 3.0.2-preview.1))
   (pbrt_services
-   (>= 3.0))
+   (>= 3.0.2-preview.1))
   (ppx_jane
    (and
     (>= v0.16)

--- a/dune-project
+++ b/dune-project
@@ -29,9 +29,9 @@
   (grpc-protoc
    (>= 0.2.0-preview.2))
   (ocaml-protoc
-   (>= 3.0.2-preview.1))
+   (>= 3.0.2-preview.2))
   (pbrt_services
-   (>= 3.0.2-preview.1))
+   (>= 3.0.2-preview.2))
   (ppx_js_style
    (and
     (>= v0.16)
@@ -177,9 +177,9 @@
   (grpc-stream
    (= :version))
   (pbrt
-   (>= 3.0.2-preview.1))
+   (>= 3.0.2-preview.2))
   (pbrt_services
-   (>= 3.0.2-preview.1))
+   (>= 3.0.2-preview.2))
   (ppx_jane
    (and
     (>= v0.16)

--- a/eio-rpc-example.opam
+++ b/eio-rpc-example.opam
@@ -22,8 +22,8 @@ depends: [
   "grpc-server" {= version}
   "grpc-spec" {= version}
   "grpc-stream" {= version}
-  "pbrt" {>= "3.0"}
-  "pbrt_services" {>= "3.0"}
+  "pbrt" {>= "3.0.2-preview.1"}
+  "pbrt_services" {>= "3.0.2-preview.1"}
   "ppx_jane" {>= "v0.16" & < "v0.17"}
   "ppx_js_style" {>= "v0.16" & < "v0.17"}
   "stdio" {>= "v0.16" & < "v0.17"}

--- a/eio-rpc-example.opam
+++ b/eio-rpc-example.opam
@@ -22,8 +22,8 @@ depends: [
   "grpc-server" {= version}
   "grpc-spec" {= version}
   "grpc-stream" {= version}
-  "pbrt" {>= "3.0.2-preview.1"}
-  "pbrt_services" {>= "3.0.2-preview.1"}
+  "pbrt" {>= "3.0.2-preview.2"}
+  "pbrt_services" {>= "3.0.2-preview.2"}
   "ppx_jane" {>= "v0.16" & < "v0.17"}
   "ppx_js_style" {>= "v0.16" & < "v0.17"}
   "stdio" {>= "v0.16" & < "v0.17"}

--- a/example/keyval/lib/keyval_rpc/src/delete.ml
+++ b/example/keyval/lib/keyval_rpc/src/delete.ml
@@ -14,7 +14,7 @@ module Response = Proto_unit_or_error
 let rpc =
   Grpc_spec.unary
     ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.delete
-    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_delete
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.delete
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/delete.ml
+++ b/example/keyval/lib/keyval_rpc/src/delete.ml
@@ -13,7 +13,8 @@ module Response = Proto_unit_or_error
 
 let rpc =
   Grpc_spec.unary
-    Keyval_rpc_proto.Keyval.Keyval.Client.delete
+    ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.delete
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_delete
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/delete.mli
+++ b/example/keyval/lib/keyval_rpc/src/delete.mli
@@ -6,9 +6,4 @@ module Response : sig
   type t = unit Or_error.t [@@deriving compare, equal, hash, sexp_of]
 end
 
-val rpc
-  : ( Keyval_rpc_proto.Keyval.key
-      , Request.t
-      , Keyval_rpc_proto.Keyval.unit_or_error
-      , Response.t )
-      Grpc_spec.unary
+val rpc : (Request.t, Response.t) Grpc_spec.unary

--- a/example/keyval/lib/keyval_rpc/src/get.ml
+++ b/example/keyval/lib/keyval_rpc/src/get.ml
@@ -14,7 +14,7 @@ module Response = Proto_value_or_error
 let rpc =
   Grpc_spec.unary
     ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.get
-    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_get
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.get
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/get.ml
+++ b/example/keyval/lib/keyval_rpc/src/get.ml
@@ -13,7 +13,8 @@ module Response = Proto_value_or_error
 
 let rpc =
   Grpc_spec.unary
-    Keyval_rpc_proto.Keyval.Keyval.Client.get
+    ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.get
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_get
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/get.mli
+++ b/example/keyval/lib/keyval_rpc/src/get.mli
@@ -6,9 +6,4 @@ module Response : sig
   type t = Keyval.Value.t Or_error.t [@@deriving compare, equal, hash, sexp_of]
 end
 
-val rpc
-  : ( Keyval_rpc_proto.Keyval.key
-      , Request.t
-      , Keyval_rpc_proto.Keyval.value_or_error
-      , Response.t )
-      Grpc_spec.unary
+val rpc : (Request.t, Response.t) Grpc_spec.unary

--- a/example/keyval/lib/keyval_rpc/src/list_keys.ml
+++ b/example/keyval/lib/keyval_rpc/src/list_keys.ml
@@ -27,7 +27,7 @@ end
 let rpc =
   Grpc_spec.unary
     ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.listKeys
-    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_listKeys
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.listKeys
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/list_keys.ml
+++ b/example/keyval/lib/keyval_rpc/src/list_keys.ml
@@ -26,7 +26,8 @@ end
 
 let rpc =
   Grpc_spec.unary
-    Keyval_rpc_proto.Keyval.Keyval.Client.listKeys
+    ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.listKeys
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_listKeys
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/list_keys.mli
+++ b/example/keyval/lib/keyval_rpc/src/list_keys.mli
@@ -6,9 +6,4 @@ module Response : sig
   type t = Set.M(Keyval.Key).t [@@deriving compare, equal, hash, sexp_of]
 end
 
-val rpc
-  : ( Keyval_rpc_proto.Keyval.unit_
-      , Request.t
-      , Keyval_rpc_proto.Keyval.keys
-      , Response.t )
-      Grpc_spec.unary
+val rpc : (Request.t, Response.t) Grpc_spec.unary

--- a/example/keyval/lib/keyval_rpc/src/set_.ml
+++ b/example/keyval/lib/keyval_rpc/src/set_.ml
@@ -20,7 +20,8 @@ module Response = Proto_unit
 
 let rpc =
   Grpc_spec.unary
-    Keyval_rpc_proto.Keyval.Keyval.Client.set
+    ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.set
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_set
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/set_.ml
+++ b/example/keyval/lib/keyval_rpc/src/set_.ml
@@ -21,7 +21,7 @@ module Response = Proto_unit
 let rpc =
   Grpc_spec.unary
     ~client_rpc:Keyval_rpc_proto.Keyval.Keyval.Client.set
-    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.rpc_set
+    ~server_rpc:Keyval_rpc_proto.Keyval.Keyval.Server.set
     (module Request)
     (module Response)
 ;;

--- a/example/keyval/lib/keyval_rpc/src/set_.mli
+++ b/example/keyval/lib/keyval_rpc/src/set_.mli
@@ -6,9 +6,4 @@ module Response : sig
   type t = unit [@@deriving compare, equal, hash, sexp_of]
 end
 
-val rpc
-  : ( Keyval_rpc_proto.Keyval.keyval_pair
-      , Request.t
-      , Keyval_rpc_proto.Keyval.unit_
-      , Response.t )
-      Grpc_spec.unary
+val rpc : (Request.t, Response.t) Grpc_spec.unary

--- a/example/keyval/lib/keyval_server/src/keyval_server.ml
+++ b/example/keyval/lib/keyval_server/src/keyval_server.ml
@@ -23,16 +23,10 @@ let delete t key =
 let list_keys t = Hashtbl.keys t.table |> Set.of_list (module Keyval.Key)
 
 let implement_rpcs t =
-  Keyval_rpc_proto.Keyval.Keyval.Server.make
-    ~get:(fun rpc ->
-      Grpc_server.Rpc.unary rpc Keyval_rpc.Get.rpc ~f:(fun key -> get t key))
-    ~set:(fun rpc ->
-      Grpc_server.Rpc.unary rpc Keyval_rpc.Set_.rpc ~f:(fun keyval_pair ->
-        set t keyval_pair))
-    ~delete:(fun rpc ->
-      Grpc_server.Rpc.unary rpc Keyval_rpc.Delete.rpc ~f:(fun key -> delete t key))
-    ~listKeys:(fun rpc ->
-      Grpc_server.Rpc.unary rpc Keyval_rpc.List_keys.rpc ~f:(fun () -> list_keys t))
-    ()
-  |> Grpc_server.implement
+  Grpc_server.implement
+    [ Grpc_server.Rpc.unary Keyval_rpc.Get.rpc ~f:(fun key -> get t key)
+    ; Grpc_server.Rpc.unary Keyval_rpc.Set_.rpc ~f:(fun keyval_pair -> set t keyval_pair)
+    ; Grpc_server.Rpc.unary Keyval_rpc.Delete.rpc ~f:(fun key -> delete t key)
+    ; Grpc_server.Rpc.unary Keyval_rpc.List_keys.rpc ~f:(fun () -> list_keys t)
+    ]
 ;;

--- a/grpc-spec.opam
+++ b/grpc-spec.opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "5.1"}
   "grpc" {>= "0.2.0-preview.2"}
   "grpc-protoc" {>= "0.2.0-preview.2"}
-  "ocaml-protoc" {>= "3.0"}
-  "pbrt_services" {>= "3.0"}
+  "ocaml-protoc" {>= "3.0.2-preview.1"}
+  "pbrt_services" {>= "3.0.2-preview.1"}
   "ppx_js_style" {>= "v0.16" & < "v0.17"}
   "odoc" {with-doc}
 ]

--- a/grpc-spec.opam
+++ b/grpc-spec.opam
@@ -15,8 +15,8 @@ depends: [
   "ocaml" {>= "5.1"}
   "grpc" {>= "0.2.0-preview.2"}
   "grpc-protoc" {>= "0.2.0-preview.2"}
-  "ocaml-protoc" {>= "3.0.2-preview.1"}
-  "pbrt_services" {>= "3.0.2-preview.1"}
+  "ocaml-protoc" {>= "3.0.2-preview.2"}
+  "pbrt_services" {>= "3.0.2-preview.2"}
   "ppx_js_style" {>= "v0.16" & < "v0.17"}
   "odoc" {with-doc}
 ]

--- a/lib/grpc_client/src/grpc_client.mli
+++ b/lib/grpc_client/src/grpc_client.mli
@@ -16,25 +16,25 @@ val with_connection
   first class module as first argument, rather than the [val rpc] value. TBD. *)
 
 val unary
-  :  (_, 'request, _, 'response) Grpc_spec.unary
+  :  ('request, 'response) Grpc_spec.unary
   -> connection:Connection.t
   -> 'request
   -> 'response Or_error.t
 
 val server_streaming
-  :  (_, 'request, _, 'response) Grpc_spec.server_streaming
+  :  ('request, 'response) Grpc_spec.server_streaming
   -> connection:Connection.t
   -> 'request
   -> 'response Grpc_stream.t Or_error.t
 
 val client_streaming
-  :  (_, 'request, _, 'response) Grpc_spec.client_streaming
+  :  ('request, 'response) Grpc_spec.client_streaming
   -> connection:Connection.t
   -> f:('request Grpc_stream.Writer.t -> 'response option Eio.Promise.t -> 'a)
   -> 'a Or_error.t
 
 val bidirectional_streaming
-  :  (_, 'request, _, 'response) Grpc_spec.bidirectional_streaming
+  :  ('request, 'response) Grpc_spec.bidirectional_streaming
   -> connection:Connection.t
   -> f:('request Grpc_stream.Writer.t -> 'response Grpc_stream.t -> 'a)
   -> 'a Or_error.t

--- a/lib/grpc_server/src/grpc_server.ml
+++ b/lib/grpc_server/src/grpc_server.ml
@@ -1,31 +1,29 @@
 module Rpc = struct
-  type t = unit Grpc_eio.Server.Typed_rpc.t
+  type t = Grpc.Rpc.Service_spec.t Grpc_eio.Server.Typed_rpc.t
 
-  let unary proto_rpc rpc ~f =
-    Grpc_eio.Server.Typed_rpc.unary (Grpc_spec.server_rpc proto_rpc rpc) ~f:(fun req ->
+  let unary rpc ~f =
+    Grpc_eio.Server.Typed_rpc.unary (Grpc_spec.server_rpc rpc) ~f:(fun req ->
       let res = f req in
       Grpc.Status.v OK, Some res)
   ;;
 
-  let client_streaming proto_rpc rpc ~f =
-    Grpc_eio.Server.Typed_rpc.client_streaming
-      (Grpc_spec.server_rpc proto_rpc rpc)
-      ~f:(fun req ->
-        let res = f req in
-        Grpc.Status.v OK, Some res)
+  let client_streaming rpc ~f =
+    Grpc_eio.Server.Typed_rpc.client_streaming (Grpc_spec.server_rpc rpc) ~f:(fun req ->
+      let res = f req in
+      Grpc.Status.v OK, Some res)
   ;;
 
-  let server_streaming proto_rpc rpc ~f =
+  let server_streaming rpc ~f =
     Grpc_eio.Server.Typed_rpc.server_streaming
-      (Grpc_spec.server_rpc proto_rpc rpc)
+      (Grpc_spec.server_rpc rpc)
       ~f:(fun req send_response ->
         f req ~send_response;
         Grpc.Status.v OK)
   ;;
 
-  let bidirectional_streaming proto_rpc rpc ~f =
+  let bidirectional_streaming rpc ~f =
     Grpc_eio.Server.Typed_rpc.bidirectional_streaming
-      (Grpc_spec.server_rpc proto_rpc rpc)
+      (Grpc_spec.server_rpc rpc)
       ~f:(fun req send_response ->
         f req ~send_response;
         Grpc.Status.v OK)
@@ -34,7 +32,7 @@ end
 
 type t = Grpc_eio.Server.t
 
-let implement server = server |> Grpc_protoc.handlers |> Grpc_eio.Server.Typed_rpc.server
+let implement handlers = Grpc_eio.Server.Typed_rpc.server (Handlers { handlers })
 
 let connection_handler server ~sw =
   let error_handler client_address ?request:_ _error start_response =

--- a/lib/grpc_server/src/grpc_server.mli
+++ b/lib/grpc_server/src/grpc_server.mli
@@ -1,74 +1,38 @@
 module Rpc : sig
-  type t = unit Grpc_eio.Server.Typed_rpc.t
+  type t = Grpc.Rpc.Service_spec.t Grpc_eio.Server.Typed_rpc.t
 
   val unary
-    :  ( 'proto_request
-         , Pbrt_services.Value_mode.unary
-         , 'proto_response
-         , Pbrt_services.Value_mode.unary )
-         Pbrt_services.Server.rpc
-    -> ( 'proto_request
-         , 'request
+    :  ( 'request
          , Grpc_spec.Value_mode.unary
-         , Pbrt_services.Value_mode.unary
-         , 'proto_response
          , 'response
-         , Grpc_spec.Value_mode.unary
-         , Pbrt_services.Value_mode.unary )
+         , Grpc_spec.Value_mode.unary )
          Grpc_spec.t
     -> f:('request -> 'response)
     -> t
 
   val client_streaming
-    :  ( 'proto_request
-         , Pbrt_services.Value_mode.stream
-         , 'proto_response
-         , Pbrt_services.Value_mode.unary )
-         Pbrt_services.Server.rpc
-    -> ( 'proto_request
-         , 'request
+    :  ( 'request
          , Grpc_spec.Value_mode.stream
-         , Pbrt_services.Value_mode.stream
-         , 'proto_response
          , 'response
-         , Grpc_spec.Value_mode.unary
-         , Pbrt_services.Value_mode.unary )
+         , Grpc_spec.Value_mode.unary )
          Grpc_spec.t
     -> f:('request Grpc_stream.t -> 'response)
     -> t
 
   val server_streaming
-    :  ( 'proto_request
-         , Pbrt_services.Value_mode.unary
-         , 'proto_response
-         , Pbrt_services.Value_mode.stream )
-         Pbrt_services.Server.rpc
-    -> ( 'proto_request
-         , 'request
+    :  ( 'request
          , Grpc_spec.Value_mode.unary
-         , Pbrt_services.Value_mode.unary
-         , 'proto_response
          , 'response
-         , Grpc_spec.Value_mode.stream
-         , Pbrt_services.Value_mode.stream )
+         , Grpc_spec.Value_mode.stream )
          Grpc_spec.t
     -> f:('request -> send_response:('response -> unit) -> unit)
     -> t
 
   val bidirectional_streaming
-    :  ( 'proto_request
-         , Pbrt_services.Value_mode.stream
-         , 'proto_response
-         , Pbrt_services.Value_mode.stream )
-         Pbrt_services.Server.rpc
-    -> ( 'proto_request
-         , 'request
+    :  ( 'request
          , Grpc_spec.Value_mode.stream
-         , Pbrt_services.Value_mode.stream
-         , 'proto_response
          , 'response
-         , Grpc_spec.Value_mode.stream
-         , Pbrt_services.Value_mode.stream )
+         , Grpc_spec.Value_mode.stream )
          Grpc_spec.t
     -> f:('request Grpc_stream.t -> send_response:('response -> unit) -> unit)
     -> t
@@ -76,7 +40,7 @@ end
 
 type t
 
-val implement : Rpc.t Pbrt_services.Server.t -> t
+val implement : Rpc.t list -> t
 
 val connection_handler
   :  t

--- a/lib/grpc_spec/src/grpc_spec.mli
+++ b/lib/grpc_spec/src/grpc_spec.mli
@@ -3,61 +3,21 @@ module Value_mode : sig
   type stream = Grpc.Rpc.Value_mode.stream
 end
 
-type ('proto_request
-     , 'request
-     , 'request_mode
-     , 'protoc_request_mode
-     , 'proto_response
-     , 'response
-     , 'response_mode
-     , 'protoc_response_mode)
-     t
+type ('request, 'request_mode, 'response, 'response_mode) t
 
 (** Some type aliases to help managing the complexity of the types. *)
 
-type ('proto_request, 'request, 'proto_response, 'response) unary =
-  ( 'proto_request
-    , 'request
-    , Value_mode.unary
-    , Pbrt_services.Value_mode.unary
-    , 'proto_response
-    , 'response
-    , Value_mode.unary
-    , Pbrt_services.Value_mode.unary )
-    t
+type ('request, 'response) unary =
+  ('request, Value_mode.unary, 'response, Value_mode.unary) t
 
-type ('proto_request, 'request, 'proto_response, 'response) server_streaming =
-  ( 'proto_request
-    , 'request
-    , Value_mode.unary
-    , Pbrt_services.Value_mode.unary
-    , 'proto_response
-    , 'response
-    , Value_mode.stream
-    , Pbrt_services.Value_mode.stream )
-    t
+type ('request, 'response) server_streaming =
+  ('request, Value_mode.unary, 'response, Value_mode.stream) t
 
-type ('proto_request, 'request, 'proto_response, 'response) client_streaming =
-  ( 'proto_request
-    , 'request
-    , Value_mode.stream
-    , Pbrt_services.Value_mode.stream
-    , 'proto_response
-    , 'response
-    , Value_mode.unary
-    , Pbrt_services.Value_mode.unary )
-    t
+type ('request, 'response) client_streaming =
+  ('request, Value_mode.stream, 'response, Value_mode.unary) t
 
-type ('proto_request, 'request, 'proto_response, 'response) bidirectional_streaming =
-  ( 'proto_request
-    , 'request
-    , Value_mode.stream
-    , Pbrt_services.Value_mode.stream
-    , 'proto_response
-    , 'response
-    , Value_mode.stream
-    , Pbrt_services.Value_mode.stream )
-    t
+type ('request, 'response) bidirectional_streaming =
+  ('request, Value_mode.stream, 'response, Value_mode.stream) t
 
 (** {1 Creating RPC apis} *)
 
@@ -75,44 +35,72 @@ module Protoable : sig
 end
 
 val unary
-  :  ( 'proto_request
-       , Pbrt_services.Value_mode.unary
-       , 'proto_response
-       , Pbrt_services.Value_mode.unary )
-       Pbrt_services.Client.rpc
+  :  client_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.unary
+         , 'proto_response
+         , Pbrt_services.Value_mode.unary )
+         Pbrt_services.Client.rpc
+  -> server_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.unary
+         , 'proto_response
+         , Pbrt_services.Value_mode.unary )
+         Pbrt_services.Server.rpc
   -> (module Protoable.S with type t = 'request and type Proto.t = 'proto_request)
   -> (module Protoable.S with type t = 'response and type Proto.t = 'proto_response)
-  -> ('proto_request, 'request, 'proto_response, 'response) unary
+  -> ('request, 'response) unary
 
 val server_streaming
-  :  ( 'proto_request
-       , Pbrt_services.Value_mode.unary
-       , 'proto_response
-       , Pbrt_services.Value_mode.stream )
-       Pbrt_services.Client.rpc
+  :  client_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.unary
+         , 'proto_response
+         , Pbrt_services.Value_mode.stream )
+         Pbrt_services.Client.rpc
+  -> server_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.unary
+         , 'proto_response
+         , Pbrt_services.Value_mode.stream )
+         Pbrt_services.Server.rpc
   -> (module Protoable.S with type t = 'request and type Proto.t = 'proto_request)
   -> (module Protoable.S with type t = 'response and type Proto.t = 'proto_response)
-  -> ('proto_request, 'request, 'proto_response, 'response) server_streaming
+  -> ('request, 'response) server_streaming
 
 val client_streaming
-  :  ( 'proto_request
-       , Pbrt_services.Value_mode.stream
-       , 'proto_response
-       , Pbrt_services.Value_mode.unary )
-       Pbrt_services.Client.rpc
+  :  client_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.stream
+         , 'proto_response
+         , Pbrt_services.Value_mode.unary )
+         Pbrt_services.Client.rpc
+  -> server_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.stream
+         , 'proto_response
+         , Pbrt_services.Value_mode.unary )
+         Pbrt_services.Server.rpc
   -> (module Protoable.S with type t = 'request and type Proto.t = 'proto_request)
   -> (module Protoable.S with type t = 'response and type Proto.t = 'proto_response)
-  -> ('proto_request, 'request, 'proto_response, 'response) client_streaming
+  -> ('request, 'response) client_streaming
 
 val bidirectional_streaming
-  :  ( 'proto_request
-       , Pbrt_services.Value_mode.stream
-       , 'proto_response
-       , Pbrt_services.Value_mode.stream )
-       Pbrt_services.Client.rpc
+  :  client_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.stream
+         , 'proto_response
+         , Pbrt_services.Value_mode.stream )
+         Pbrt_services.Client.rpc
+  -> server_rpc:
+       ( 'proto_request
+         , Pbrt_services.Value_mode.stream
+         , 'proto_response
+         , Pbrt_services.Value_mode.stream )
+         Pbrt_services.Server.rpc
   -> (module Protoable.S with type t = 'request and type Proto.t = 'proto_request)
   -> (module Protoable.S with type t = 'response and type Proto.t = 'proto_response)
-  -> ('proto_request, 'request, 'proto_response, 'response) bidirectional_streaming
+  -> ('request, 'response) bidirectional_streaming
 
 (** {1 Grpc Utils}
 
@@ -121,24 +109,16 @@ val bidirectional_streaming
 
 (** [client_rpc] is used by the implementation of {!module:Grpc_client}. *)
 val client_rpc
-  :  (_, 'request, 'request_mode, _, _, 'response, 'response_mode, _) t
+  :  ('request, 'request_mode, 'response, 'response_mode) t
   -> ('request, 'request_mode, 'response, 'response_mode) Grpc.Rpc.Client_rpc.t
 
 (** [server_rpc] is used by {!module:Grpc_server} to furnish the server
     implementation for a given RPC. *)
 val server_rpc
-  :  ( 'proto_request
-       , 'protoc_request_mode
-       , 'proto_response
-       , 'protoc_response_mode )
-       Pbrt_services.Server.rpc
-  -> ( 'proto_request
-       , 'request
+  :  ('request, 'request_mode, 'response, 'response_mode) t
+  -> ( 'request
        , 'request_mode
-       , 'protoc_request_mode
-       , 'proto_response
        , 'response
        , 'response_mode
-       , 'protoc_response_mode )
-       t
-  -> ('request, 'request_mode, 'response, 'response_mode, unit) Grpc.Rpc.Server_rpc.t
+       , Grpc.Rpc.Service_spec.t )
+       Grpc.Rpc.Server_rpc.t


### PR DESCRIPTION
I am considering a modification to the `Grpc_spec` interface. Specifically, I
suggest that we require the protoc `server_rpc` endpoint in addition to the
`client_rpc`.

One of the key benefits of this approach is that the types exported by
`Grpc_spec` would only have two parameters, `request` and `response`. This
simplification would streamline the interface of all the RPCs, as well as the
`Grpc_client` and `Grpc_server` interfaces. Importantly, these two interfaces
would no longer reference any `protoc` specific code or generated code,
enhancing their robustness against potential future internal changes.

However, there is a downside to this approach: we would lose the compile-time
check that a server implements all the RPCs defined in a service declared in the
`*.proto` file. To mitigate this, I plan to rely on unit tests instead.

In my opinion, the benefits of this approach outweigh the downside for the
`eio-rpc` case.

Please note that this proposal requires a change to `ocaml-protoc`, which
currently does not export the server stubs. I am in the process of discussing
this with the `ocaml-protoc` maintainers.
