### PR TITLE
Fix server coverage

### DIFF
--- a/example/keyval/test/dune
+++ b/example/keyval/test/dune
@@ -2,7 +2,7 @@
  (name keyval_functional_test)
  (public_name eio-rpc.keyval-functional-test)
  (inline_tests
-  (deps %{bin:keyval}))
+  (deps keyval.exe))
  (flags
   :standard
   -w
@@ -26,3 +26,6 @@
   (backend bisect_ppx))
  (preprocess
   (pps ppx_jane ppx_js_style -check-doc-comments ppx-let-fun)))
+
+(rule
+ (copy ../bin/main.exe keyval.exe))

--- a/example/keyval/test/keyval_test.ml
+++ b/example/keyval/test/keyval_test.ml
@@ -1,4 +1,4 @@
-let executable = "keyval"
+let executable = "./keyval.exe"
 
 let config =
   Grpc_test.Config.grpc_discovery

--- a/lib/grpc_test/src/grpc_test.ml
+++ b/lib/grpc_test/src/grpc_test.ml
@@ -182,7 +182,7 @@ let with_server ?(sockaddr_kind = Sockaddr_kind.Unix_socket) (T { env } as t) ~c
   Exn.protect
     ~f:(fun () ->
       f { With_server.server; client };
-      Eio.Process.signal server_process Stdlib.Sys.sigint;
+      Eio.Process.signal server_process Stdlib.Sys.sigterm;
       match Eio.Process.await server_process with
       | `Exited _ | `Signaled _ -> ())
     ~finally:(fun () ->


### PR DESCRIPTION
**Problem:**
The current setup does not generate `bisect_ppx` data for the server binary. As a result, the coverage report shows `0.0%` for all server libraries, even though they are exercised during tests. This is due to the test process terminating the server in a way that prevents it from generating the coverage data.

**Solution:**
This PR addresses this issue by modifying the way the server is terminated during tests, allowing it to generate and report coverage data correctly.

**Benefits:**
With this fix, we can ensure more accurate coverage reporting for the server libraries, leading to better insights into our test coverage and areas that might need more testing.