### PR TITLE
Switch syntax from ppx-let-fun to let-fun (let&)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -436,6 +436,8 @@
    (= :version))
   (grpc-stream
    (= :version))
+  (letfun
+   (>= 0.0.1))
   (ocamlformat
    (and
     :with-test
@@ -450,8 +452,6 @@
    (>= 3.0.2-preview.4))
   (pbrt_services
    (>= 3.0.2-preview.4))
-  (ppx-let-fun
-   (>= 0.0.2))
   (ppx_compare
    (and
     (>= v0.16)

--- a/eio-rpc.opam
+++ b/eio-rpc.opam
@@ -24,12 +24,12 @@ depends: [
   "grpc-server" {= version}
   "grpc-spec" {= version}
   "grpc-stream" {= version}
+  "letfun" {>= "0.0.1"}
   "ocamlformat" {with-test & = "0.26.2"}
   "parsexp" {>= "v0.16" & < "v0.17"}
   "pbrt" {>= "3.0.2-preview.4"}
   "pbrt_quickcheck" {>= "3.0.2-preview.4"}
   "pbrt_services" {>= "3.0.2-preview.4"}
-  "ppx-let-fun" {>= "0.0.2"}
   "ppx_compare" {>= "v0.16" & < "v0.17"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_qcheck" {>= "0.4.1"}

--- a/example/keyval/lib/keyval/src/dune
+++ b/example/keyval/lib/keyval/src/dune
@@ -15,7 +15,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval/test/dune
+++ b/example/keyval/lib/keyval/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_command/src/dune
+++ b/example/keyval/lib/keyval_command/src/dune
@@ -24,7 +24,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_command/test/dune
+++ b/example/keyval/lib/keyval_command/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_rpc/src/dune
+++ b/example/keyval/lib/keyval_rpc/src/dune
@@ -15,7 +15,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_rpc/test/dune
+++ b/example/keyval/lib/keyval_rpc/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_server/src/dune
+++ b/example/keyval/lib/keyval_server/src/dune
@@ -6,7 +6,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/lib/keyval_server/test/dune
+++ b/example/keyval/lib/keyval_server/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/example/keyval/test/dune
+++ b/example/keyval/test/dune
@@ -12,7 +12,9 @@
   -open
   Base
   -open
-  Expect_test_helpers)
+  Expect_test_helpers
+  -open
+  Letfun)
  (libraries
   base
   eio
@@ -21,11 +23,12 @@
   grpc_client
   grpc_test
   keyval
-  keyval_rpc)
+  keyval_rpc
+  letfun)
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare
@@ -35,8 +38,7 @@
    ppx_here
    ppx_let
    ppx_sexp_conv
-   ppx_sexp_value
-   ppx-let-fun)))
+   ppx_sexp_value)))
 
 (rule
  (copy ../bin/main.exe keyval.exe))

--- a/example/keyval/test/test__cli.ml
+++ b/example/keyval/test/test__cli.ml
@@ -4,9 +4,9 @@
    instead of bash. *)
 
 let%expect_test "using the cli" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
-  let%fun.F { server = _; client = keyval } =
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
+  let&- { server = _; client = keyval } =
     Grpc_test.with_server t ~config:Keyval_test.config
   in
   (* At first, there are no keys in the server. *)

--- a/example/keyval/test/test__connection.ml
+++ b/example/keyval/test/test__connection.ml
@@ -2,9 +2,9 @@
    addition to the cli. *)
 
 let%expect_test "with_connection" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
-  let%fun.F { server; client = keyval } =
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
+  let&- { server; client = keyval } =
     Grpc_test.with_server t ~config:Keyval_test.config
   in
   (* First lets's store a binding to the store. *)
@@ -12,7 +12,7 @@ let%expect_test "with_connection" =
   keyval [ [ "get" ]; [ "--key"; "foo" ] ];
   [%expect {| bar |}];
   (* Now let's start access that binding using the RPC api. *)
-  let%fun.F connection = Grpc_test.Server.with_connection server in
+  let&- connection = Grpc_test.Server.with_connection server in
   let data =
     Grpc_client.unary (module Keyval_rpc.Get) ~connection (Keyval.Key.v "foo")
     |> Or_error.join

--- a/example/keyval/test/test__multiple_servers.ml
+++ b/example/keyval/test/test__multiple_servers.ml
@@ -40,16 +40,16 @@ let all_bindings ~connection =
 ;;
 
 let%expect_test "two servers" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
-  let%fun.F { server = server1; client = cli1 } =
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
+  let&- { server = server1; client = cli1 } =
     Grpc_test.with_server t ~config:Keyval_test.config
   in
-  let%fun.F { server = server2; client = cli2 } =
+  let&- { server = server2; client = cli2 } =
     Grpc_test.with_server t ~config:Keyval_test.config
   in
-  let%fun.F connection1 = Grpc_test.Server.with_connection server1 in
-  let%fun.F connection2 = Grpc_test.Server.with_connection server2 in
+  let&- connection1 = Grpc_test.Server.with_connection server1 in
+  let&- connection2 = Grpc_test.Server.with_connection server2 in
   (* At first, none of the servers have keys. *)
   cli1 [ [ "list-keys" ] ];
   [%expect {| () |}];

--- a/example/keyval/test/test__server_restart.ml
+++ b/example/keyval/test/test__server_restart.ml
@@ -4,8 +4,8 @@
    database). *)
 
 let%expect_test "testing server restart" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
   Grpc_test.with_server t ~config:Keyval_test.config ~f:(fun { client = keyval; _ } ->
     keyval [ [ "list-keys" ] ];
     [%expect {| () |}];

--- a/example/keyval/test/test__tcp.ml
+++ b/example/keyval/test/test__tcp.ml
@@ -1,9 +1,9 @@
 (* In this test we connect to the server using tcp rather than via a unix socket. *)
 
 let%expect_test "using tcp" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
-  let%fun.F { server; client = keyval } =
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
+  let&- { server; client = keyval } =
     Grpc_test.with_server t ~config:Keyval_test.config ~sockaddr_kind:Tcp_localhost
   in
   (* First lets's store a binding to the store. *)
@@ -11,7 +11,7 @@ let%expect_test "using tcp" =
   keyval [ [ "get" ]; [ "--key"; "foo" ] ];
   [%expect {| bar |}];
   (* Now let's start access that binding using the RPC api. *)
-  let%fun.F connection = Grpc_test.Server.with_connection server in
+  let&- connection = Grpc_test.Server.with_connection server in
   let data =
     Grpc_client.unary (module Keyval_rpc.Get) ~connection (Keyval.Key.v "foo")
     |> Or_error.join

--- a/example/keyval/test/test__validate_key.ml
+++ b/example/keyval/test/test__validate_key.ml
@@ -2,9 +2,9 @@
    running server (offline mode). *)
 
 let%expect_test "offline" =
-  let%fun env = Eio_main.run in
-  let%fun.F t = Grpc_test.run ~env in
-  let%fun.F { server = _; client = keyval } =
+  let& env = Eio_main.run in
+  let&- t = Grpc_test.run ~env in
+  let&- { server = _; client = keyval } =
     Grpc_test.with_server t ~config:Keyval_test.config
   in
   (* By default, [Grpc_test] adds to all commands invocation the necessary

--- a/lib/grpc_client/src/dune
+++ b/lib/grpc_client/src/dune
@@ -15,7 +15,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_client/test/dune
+++ b/lib/grpc_client/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_discovery/src/dune
+++ b/lib/grpc_discovery/src/dune
@@ -17,7 +17,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_discovery/test/dune
+++ b/lib/grpc_discovery/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_quickcheck/src/dune
+++ b/lib/grpc_quickcheck/src/dune
@@ -15,7 +15,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_quickcheck/test/dune
+++ b/lib/grpc_quickcheck/test/dune
@@ -15,7 +15,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_server/src/dune
+++ b/lib/grpc_server/src/dune
@@ -6,7 +6,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_server/test/dune
+++ b/lib/grpc_server/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_spec/src/dune
+++ b/lib/grpc_spec/src/dune
@@ -6,7 +6,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_spec/test/dune
+++ b/lib/grpc_spec/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_stream/test/dune
+++ b/lib/grpc_stream/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_test/src/dune
+++ b/lib/grpc_test/src/dune
@@ -6,7 +6,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare

--- a/lib/grpc_test/test/dune
+++ b/lib/grpc_test/test/dune
@@ -16,7 +16,7 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
   (pps
    ppx_compare


### PR DESCRIPTION
I wish to deprecate `ppx-let-fun` and have been experimenting with `let-fun` (`let&`) instead.

`let&-` is to be used instead of `let&` when the argument expected by the closure is labeled `~f`.

This is a refactoring with no behavior change.